### PR TITLE
Feat: CheckboxInfoRow component

### DIFF
--- a/packages/design-platform/src/App.tsx
+++ b/packages/design-platform/src/App.tsx
@@ -1,20 +1,40 @@
 import ButtonExamples from "./components/Button/Button.simple";
+// import CheckboxInfoList from "./components/CheckboxInfoList";
+import { CheckboxInfoRow } from "./components/CheckboxInfoRow/CheckboxInfoRow";
 import { ExpandTab } from "./components/ExpandTab/ExpandTab";
 import styles from "./styles.module.css"
+
+// const dummyDataForCheckboxInfoList = [
+//   { title: 'Non Stop', description: '$ 100', isChecked: false },
+//   { title: '1 Stop', description: '$ 80', isChecked: true },
+//   { title: '2+ Stops', description: '$ 50', isChecked: false },
+//   { title: 'Red Eye Flights', description: '$ 120', isChecked: false },
+//   { title: 'Early Morning Flights', description: '$ 110', isChecked: true },
+//   { title: 'Late Night Flights', description: '$ 90', isChecked: false },
+// ];
 
 function App() {
   return (
     <div className={styles.app}>
-      <h1>Design  System</h1>
+      <div className={styles.spacer}>
+        <h1>Design  System</h1>
+      </div>
 
-      <h2>Buttons</h2>
       <ExpandTab title="Button Examples">
         <ButtonExamples />
       </ExpandTab>
 
       <div className={styles.spacer}>
-        <ExpandTab title="Checkbox">
-          <ButtonExamples />
+        <ExpandTab opened={true} title="Checkbox | Checkbox Info list">
+          <div className={styles.spacer}>
+            <h2>Single Checkbox Row</h2>
+            <CheckboxInfoRow title="Non Stop" isChecked={false} onChange={(e) => console.log(e)} description="$ 100" />
+          </div>
+
+          <div className={styles.spacer}>
+            <h2>Checkbox Info List</h2>
+            {/* <CheckboxInfoList items={dummyDataForCheckboxInfoList} isExpandable={true} minItemsToShow={3} /> */}
+          </div>
         </ExpandTab>
       </div>
     </div>

--- a/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.tsx
+++ b/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { CheckboxInfoRowProps } from "./CheckboxInfoRow.types";
+import styles from './checkboxInfoRow.module.css';
+
+export const CheckboxInfoRow = (props: CheckboxInfoRowProps) => {
+    const { title, description, isChecked, onChange } = props;
+    const [isCheckboxChecked, setIsCheckboxChecked] = useState(!!isChecked);
+
+    // Keep internal state in sync when parent changes `isChecked` prop
+    useEffect(() => {
+        if (typeof isChecked === 'boolean') setIsCheckboxChecked(isChecked);
+    }, [isChecked]);
+
+    const toggle = () => {
+        const next = !isCheckboxChecked;
+        setIsCheckboxChecked(next);
+        if (onChange) onChange(next);
+    };
+
+    return (
+        <div className={styles.checkboxInfoRow}>
+            <label className={styles.leftSection}>
+                <input
+                    type="checkbox"
+                    checked={isCheckboxChecked}
+                    onChange={toggle}
+                    className={styles.checkbox}
+                />
+                <div className={styles.title}>{title}</div>
+            </label>
+            {description && <div className={styles.description}>{description}</div>}
+        </div>
+    );
+}

--- a/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.tsx
+++ b/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.tsx
@@ -8,13 +8,15 @@ export const CheckboxInfoRow = (props: CheckboxInfoRowProps) => {
 
     // Keep internal state in sync when parent changes `isChecked` prop
     useEffect(() => {
-        if (typeof isChecked === 'boolean') setIsCheckboxChecked(isChecked);
+        setIsCheckboxChecked(isChecked);
     }, [isChecked]);
 
     const toggle = () => {
-        const next = !isCheckboxChecked;
-        setIsCheckboxChecked(next);
-        if (onChange) onChange(next);
+        setIsCheckboxChecked(prev => {
+            const next = !prev;
+            onChange(next);
+            return next;
+        });
     };
 
     return (

--- a/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.types.ts
+++ b/packages/design-platform/src/components/CheckboxInfoRow/CheckboxInfoRow.types.ts
@@ -1,0 +1,6 @@
+export type CheckboxInfoRowProps = {
+    title: string;
+    description?: string;
+    isChecked: boolean;
+    onChange: (checked: boolean) => void;   
+}

--- a/packages/design-platform/src/components/CheckboxInfoRow/checkboxInfoRow.module.css
+++ b/packages/design-platform/src/components/CheckboxInfoRow/checkboxInfoRow.module.css
@@ -1,0 +1,27 @@
+.checkboxInfoRow {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    cursor: pointer;
+}
+
+.leftSection {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.leftSection input {
+    width: 18px;
+    height: 18px;
+}
+
+.title {
+    font-size: 14px;
+}
+
+.description {
+    font-size: 14px;
+}

--- a/packages/design-platform/src/components/CheckboxInfoRow/checkboxInfoRow.module.css
+++ b/packages/design-platform/src/components/CheckboxInfoRow/checkboxInfoRow.module.css
@@ -20,6 +20,7 @@
 
 .title {
     font-size: 14px;
+    user-select: none;
 }
 
 .description {

--- a/packages/design-platform/src/components/ExpandTab/ExpandTab.tsx
+++ b/packages/design-platform/src/components/ExpandTab/ExpandTab.tsx
@@ -4,10 +4,12 @@ import styles from './expandTab.module.css';
 
 export const ExpandTab = (props: ExpandTabProps) => {
     const { children, opened } = props;
-    const [isOpen, setIsOpen] = useState(false);
+    // Initialize from `opened` to avoid an initial flicker when parent wants it opened on first render
+    const [isOpen, setIsOpen] = useState<boolean>(() => opened ?? false);
 
     const toggleOpen = () => {
-        setIsOpen(!isOpen);
+        // Use functional updater to avoid stale closures
+        setIsOpen(prev => !prev);
     };
 
     useEffect(() => {

--- a/packages/design-platform/src/components/ExpandTab/ExpandTab.tsx
+++ b/packages/design-platform/src/components/ExpandTab/ExpandTab.tsx
@@ -1,14 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ExpandTabProps } from './ExpandTab.types';
 import styles from './expandTab.module.css';
 
 export const ExpandTab = (props: ExpandTabProps) => {
-    const { children } = props;
+    const { children, opened } = props;
     const [isOpen, setIsOpen] = useState(false);
 
     const toggleOpen = () => {
         setIsOpen(!isOpen);
     };
+
+    useEffect(() => {
+        if (opened !== undefined) {
+            setIsOpen(opened);
+        }
+    }, [opened]);
 
     return (
         <div>

--- a/packages/design-platform/src/components/ExpandTab/ExpandTab.types.ts
+++ b/packages/design-platform/src/components/ExpandTab/ExpandTab.types.ts
@@ -3,6 +3,7 @@ type ExpandTabProps = {
     // Define your props here
     children?: React.ReactNode;
     title: string;
+    opened?: boolean;
 };
 
 export type { ExpandTabProps };


### PR DESCRIPTION
This pull request introduces a new `CheckboxInfoRow` component to the design system and enhances the `ExpandTab` component with an `opened` prop for better control over its expanded state. It also updates the main `App` to showcase the new checkbox row and prepares for future inclusion of a checkbox info list. The most important changes are grouped below:

**New CheckboxInfoRow Component:**

* Added the `CheckboxInfoRow` component, which displays a checkbox with a title and optional description, manages its checked state, and notifies changes via a callback. (`CheckboxInfoRow.tsx`, `CheckboxInfoRow.types.ts`, `checkboxInfoRow.module.css`) [[1]](diffhunk://#diff-c79be9abe25ce7010b96adef809d9dbc48fda07577ab88f36c8daccc5eab422eR1-R34) [[2]](diffhunk://#diff-cbea39fbd98375aa5c167b17f45dac25bca2ae3c9da6d038beba62b6b33ad2fbR1-R6) [[3]](diffhunk://#diff-ac4c66303671c21ce802c25e5ff61f20110cec6148a81986cb158f1ed1793c01R1-R27)

**ExpandTab Enhancements:**

* Updated the `ExpandTab` component to accept an optional `opened` prop, allowing its open/closed state to be controlled externally, and synchronized internal state with this prop. (`ExpandTab.tsx`, `ExpandTab.types.ts`) [[1]](diffhunk://#diff-3b723b3b21f5fcb2a5ed8028df77bcf6aca6ec07f1325e8ade399f599718e909L1-R18) [[2]](diffhunk://#diff-cf09c5a25d1c4feeb00f21ef40f99ea42616cef8c8b126a64b62765dad63a011R6)
